### PR TITLE
chore: rename npm package to pec-payment-sdk

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -1,7 +1,7 @@
-# pec-sdk
+# pec-payment-sdk
 
-[![npm version](https://img.shields.io/npm/v/pec-sdk?logo=npm&logoColor=white)](https://www.npmjs.com/package/pec-sdk)
-[![npm downloads](https://img.shields.io/npm/dm/pec-sdk?logo=npm&logoColor=white&label=downloads)](https://www.npmjs.com/package/pec-sdk)
+[![npm version](https://img.shields.io/npm/v/pec-payment-sdk?logo=npm&logoColor=white)](https://www.npmjs.com/package/pec-payment-sdk)
+[![npm downloads](https://img.shields.io/npm/dm/pec-payment-sdk?logo=npm&logoColor=white&label=downloads)](https://www.npmjs.com/package/pec-payment-sdk)
 [![GitHub stars](https://img.shields.io/github/stars/AlirezaMoVali/pec-sdk?style=flat&logo=github)](https://github.com/AlirezaMoVali/pec-sdk/stargazers)
 [![GitHub issues](https://img.shields.io/github/issues/AlirezaMoVali/pec-sdk?style=flat&logo=github)](https://github.com/AlirezaMoVali/pec-sdk/issues)
 [![GitHub license](https://img.shields.io/github/license/AlirezaMoVali/pec-sdk?style=flat)](https://github.com/AlirezaMoVali/pec-sdk/blob/main/LICENSE)
@@ -32,7 +32,7 @@ SDK نوشته‌شده با TypeScript/JavaScript برای درگاه پردا�
 ## نصب
 
 ```bash
-npm install pec-sdk
+npm install pec-payment-sdk
 ```
 
 ## شروع سریع
@@ -46,7 +46,7 @@ import {
   parseCallback,
   shouldConfirmPayment,
   isSuccessStatus,
-} from 'pec-sdk';
+} from 'pec-payment-sdk';
 
 const client = new PecClient({
   loginAccount: process.env.PEC_LOGIN_ACCOUNT!,
@@ -73,7 +73,7 @@ const {
   generateOrderId,
   parseCallback,
   shouldConfirmPayment,
-} = require('pec-sdk');
+} = require('pec-payment-sdk');
 
 const client = new PecClient({
   loginAccount: process.env.PEC_LOGIN_ACCOUNT,
@@ -124,7 +124,7 @@ PEC مبلغ را به **ریال** می‌پذیرد. مبلغ را با واح
 | `'rial'` | `500000` | `500000` ریال |
 
 ```typescript
-import { toRials } from 'pec-sdk';
+import { toRials } from 'pec-payment-sdk';
 
 toRials(50000, 'toman'); // 500000
 toRials(500000, 'rial'); // 500000
@@ -186,12 +186,12 @@ const client = new PecClient({
 
 ```javascript
 // CommonJS
-const { PecClient } = require('pec-sdk');
+const { PecClient } = require('pec-payment-sdk');
 ```
 
 ```typescript
 // ESM
-import { PecClient } from 'pec-sdk';
+import { PecClient } from 'pec-payment-sdk';
 ```
 
 ## متغیرهای محیطی (پیشنهادی)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# pec-sdk
+# pec-payment-sdk
 
-[![npm version](https://img.shields.io/npm/v/pec-sdk?logo=npm&logoColor=white)](https://www.npmjs.com/package/pec-sdk)
-[![npm downloads](https://img.shields.io/npm/dm/pec-sdk?logo=npm&logoColor=white&label=downloads)](https://www.npmjs.com/package/pec-sdk)
+[![npm version](https://img.shields.io/npm/v/pec-payment-sdk?logo=npm&logoColor=white)](https://www.npmjs.com/package/pec-payment-sdk)
+[![npm downloads](https://img.shields.io/npm/dm/pec-payment-sdk?logo=npm&logoColor=white&label=downloads)](https://www.npmjs.com/package/pec-payment-sdk)
 [![GitHub stars](https://img.shields.io/github/stars/AlirezaMoVali/pec-sdk?style=flat&logo=github)](https://github.com/AlirezaMoVali/pec-sdk/stargazers)
 [![GitHub issues](https://img.shields.io/github/issues/AlirezaMoVali/pec-sdk?style=flat&logo=github)](https://github.com/AlirezaMoVali/pec-sdk/issues)
 [![GitHub license](https://img.shields.io/github/license/AlirezaMoVali/pec-sdk?style=flat)](https://github.com/AlirezaMoVali/pec-sdk/blob/main/LICENSE)
@@ -32,7 +32,7 @@ Built on official PEC SOAP services (same endpoints as the bank’s PHP samples)
 ## Installation
 
 ```bash
-npm install pec-sdk
+npm install pec-payment-sdk
 ```
 
 ## Quick start
@@ -46,7 +46,7 @@ import {
   parseCallback,
   shouldConfirmPayment,
   isSuccessStatus,
-} from 'pec-sdk';
+} from 'pec-payment-sdk';
 
 const client = new PecClient({
   loginAccount: process.env.PEC_LOGIN_ACCOUNT!,
@@ -73,7 +73,7 @@ const {
   generateOrderId,
   parseCallback,
   shouldConfirmPayment,
-} = require('pec-sdk');
+} = require('pec-payment-sdk');
 
 const client = new PecClient({
   loginAccount: process.env.PEC_LOGIN_ACCOUNT,
@@ -124,7 +124,7 @@ PEC expects amounts in **Rials**. Pass the amount in the unit your app uses:
 | `'rial'` | `500000` | `500000` Rials |
 
 ```typescript
-import { toRials } from 'pec-sdk';
+import { toRials } from 'pec-payment-sdk';
 
 toRials(50000, 'toman'); // 500000
 toRials(500000, 'rial'); // 500000
@@ -186,12 +186,12 @@ Use the same package name in both styles — Node and bundlers pick the right bu
 
 ```javascript
 // CommonJS
-const { PecClient } = require('pec-sdk');
+const { PecClient } = require('pec-payment-sdk');
 ```
 
 ```typescript
 // ESM
-import { PecClient } from 'pec-sdk';
+import { PecClient } from 'pec-payment-sdk';
 ```
 
 ## Environment variables (recommended)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,23 @@
 {
-  "name": "pec-sdk",
+  "name": "pec-payment-sdk",
   "version": "1.1.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AlirezaMoVali/pec-sdk.git"
+  },
+  "bugs": {
+    "url": "https://github.com/AlirezaMoVali/pec-sdk/issues"
+  },
+  "homepage": "https://github.com/AlirezaMoVali/pec-sdk#readme",
+  "keywords": [
+    "pec",
+    "parsian",
+    "payment",
+    "gateway",
+    "shaparak",
+    "iran",
+    "ipg"
+  ],
   "description": "TypeScript SDK for PEC (Parsian Electronic Commerce) payment gateway.",
   "type": "commonjs",
   "main": "./dist/cjs/index.js",


### PR DESCRIPTION
## Summary

- Rename npm package from `pec-sdk` to `pec-payment-sdk` (original name was unpublished and blocked on npm)
- Add `repository`, `bugs`, `homepage`, and `keywords` to `package.json`
- Update bilingual README install/import examples and npm badges

## Test plan

- [x] `npm run build`
- [x] `npm test`
- [x] `npm publish` after merge (requires `npm login`)

Made with [Cursor](https://cursor.com)